### PR TITLE
Update changepass.py to use sha512crypt

### DIFF
--- a/pibakery-blocks/changepass/changepass.py
+++ b/pibakery-blocks/changepass/changepass.py
@@ -6,10 +6,10 @@ import subprocess,crypt,random, sys
 login = 'pi'
 password = sys.argv[1]
 
-ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-salt = ''.join(random.choice(ALPHABET) for i in range(8))
+ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ./"
+salt = ''.join(random.choice(ALPHABET) for i in range(16))
 
-shadow_password = crypt.crypt(password,'$1$'+salt+'$')
+shadow_password = crypt.crypt(password,'$6$'+salt+'$')
 
 r = subprocess.call(('usermod', '-p', shadow_password, login))
 


### PR DESCRIPTION
Update changepass.py to match Raspbian password storage (as passwd from raspi-config does)

Add ./ to ALPHABET (see http://man7.org/linux/man-pages/man3/crypt.3.html)
Increase salt to 16 characters
Change salt to use option 6   | SHA-512 (since glibc 2.7)

Switching to use urandom rather than random also suggested.