### PR TITLE
Update package to autocreate the Application Support folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ And install the required node modules using
 </br>
 This will take a few minutes to complete.
 
-If you're using Mac OS X, you'll then need to create the folder `/Library/Application Support/PiBakery/os/`, which is used to store the OS .img files. You can either do this in Finder, or by using the command
-</br>
-`mkdir -p '/Library/Application Support/PiBakery/os/'` in Terminal.
+If you're on macOS it's important you run `npm run setup` the first time [to create a folder inside Application Support](https://github.com/davidferguson/pibakery/issues/29).
 
 You can then run PiBakery using
 </br>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "David Ferguson <david@pibakery.org>",
   "license": "GPL-3.0+",
   "scripts": {
+    "setup": "npm install && if uname | grep Darwin; then mkdir -p '/Library/Application Support/PiBakery/os/'; fi"
     "start": "electron .",
     "build-mac": "find . -name .DS_Store -depth -exec rm {} \\; && npm dedupe && electron-packager ./ PiBakery --platform=darwin --arch=all --version=1.3.2 --overwrite --prune --app-version=0.2.4 --icon=./app/img/icon.icns",
     "build-win": "npm dedupe && electron-packager ./ PiBakery --platform=win32 --arch=ia32 --version=1.3.2 --overwrite --prune --app-version=0.2.4 --icon=./app/img/icon.ico"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "David Ferguson <david@pibakery.org>",
   "license": "GPL-3.0+",
   "scripts": {
-    "setup": "npm install && if uname | grep Darwin; then mkdir -p '/Library/Application Support/PiBakery/os/'; fi"
+    "setup": "npm install && if uname | grep Darwin; then mkdir -p '/Library/Application Support/PiBakery/os/'; fi",
     "start": "electron .",
     "build-mac": "find . -name .DS_Store -depth -exec rm {} \\; && npm dedupe && electron-packager ./ PiBakery --platform=darwin --arch=all --version=1.3.2 --overwrite --prune --app-version=0.2.4 --icon=./app/img/icon.icns",
     "build-win": "npm dedupe && electron-packager ./ PiBakery --platform=win32 --arch=ia32 --version=1.3.2 --overwrite --prune --app-version=0.2.4 --icon=./app/img/icon.ico"


### PR DESCRIPTION
Running `npm run setup` from package.json's run tasks will first do npm install and then check if the OS is OSX/macOS to automatically create the folder required in Application Support.

Also updated README to reflect these changes.