### PR TITLE
get rid of `find` warning on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "electron .",
     "build-mac": "find . -name .DS_Store -depth -exec rm {} \\; && npm dedupe && electron-packager ./ PiBakery --platform=darwin --arch=all --version=1.3.2 --overwrite --prune --app-version=0.3.2 --icon=./app/img/icon.icns",
     "build-win": "npm dedupe && electron-packager ./ PiBakery --platform=win32 --arch=ia32 --version=1.3.2 --overwrite --prune --app-version=0.3.2 --icon=./app/img/icon.ico",
-    "build-linux": "find . -name .DS_Store -depth -exec rm {} \\; && npm dedupe && electron-packager ./ PiBakery --platform=linux --arch=all --version=1.3.2 --overwrite --prune --app-version=0.3.2 --icon=./app/img/icon.icns"
+    "build-linux": "find . -depth -name .DS_Store -exec rm {} \\; && npm dedupe && electron-packager ./ PiBakery --platform=linux --arch=all --version=1.3.2 --overwrite --prune --app-version=0.3.2 --icon=./app/img/icon.icns"
   },
   "optionalDependencies": {
     "elevator": "^1.0.0",


### PR DESCRIPTION
Fixes this warning:
```
find: warning: you have specified the -depth option after a non-option argument -name, but options are not positional (-depth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
```
