### PR TITLE
Fix issue #97

### DIFF
--- a/app/pibakery.js
+++ b/app/pibakery.js
@@ -116,6 +116,12 @@ function initialise () {
       ipcRenderer.on('testBlock', function (event) {
         importTestBlock(dialog.showOpenDialog({properties: ['openDirectory']})[0])
       })
+      var url = new URL(window.location.href)
+      if(url.searchParams.get('importRecipe')){
+        setTimeout(function(){
+          importRecipe(url.searchParams.get('importRecipe'))
+        },2000)
+      }
     })
   })
 }

--- a/app/pibakery.js
+++ b/app/pibakery.js
@@ -120,7 +120,12 @@ function initialise () {
       if(url.searchParams.get('importRecipe')){
         setTimeout(function(){
           importRecipe(url.searchParams.get('importRecipe'))
-        },2000)
+        },1000)
+        if(url.searchParams.get('sdPath') && url.searchParams.get('sdName') && url.searchParams.get('image')){
+          setTimeout(function(){
+            _writeToSd(url.searchParams.get('sdPath'),url.searchParams.get('sdName'),url.searchParams.get('image'),url.searchParams.get('noConfirm'))
+          },2000)
+        }
       }
     })
   })
@@ -1358,17 +1363,32 @@ function writeToSd () {
   writeTryCount = 0
   var imageFile = path.normalize(getOsPath() + 'raspbian-pibakery.img')
 
-  createSdChooser(function (devicePath, name, operatingSystemFilename) {
+  createSdChooser(_writeToSd)
+}
+
+/**
+ * @desc callback for createSdChooser
+ * @param string devicePath path to sd carc
+ * @param string name name of sd card
+ * @param string operatingSystemFilename raspi image 
+ * @param boolean forceWrite dont ask for confirmation
+ * @return void
+ */
+function _writeToSd(devicePath, name, operatingSystemFilename, forceWrite) {
     if (operatingSystemFilename) {
       var imageFile = path.normalize(getOsPath() + operatingSystemFilename)
     }
-    var choice = dialog.showMessageBox(
-      {
-        type: 'question',
-        buttons: ['Yes', 'No'],
-        title: 'Confirm Write',
-        message: 'You have selected to write to "' + name + '".\nWriting will permanently erase any existing contents on "' + name + '"\nDo you wish to continue?'
-      })
+    if(forceWrite){
+      var choice = 0
+    }else{
+      var choice = dialog.showMessageBox(
+        {
+          type: 'question',
+          buttons: ['Yes', 'No'],
+          title: 'Confirm Write',
+          message: 'You have selected to write to "' + name + '".\nWriting will permanently erase any existing contents on "' + name + '"\nDo you wish to continue?'
+        })
+    }
 
     if (choice == 0) {
       // Show the "writing" animation
@@ -1408,8 +1428,7 @@ function writeToSd () {
     }else {
       document.getElementById('hider').parentNode.removeChild(document.getElementById('hider'))
     }
-  })
-}
+  }
 
 /**
   * @desc called by writeImage - only called when running on a mac, used to

--- a/main.js
+++ b/main.js
@@ -62,7 +62,8 @@ electron.app.on('ready', function()
 			icon: 'app/img/icon.png'
 		});
 
-		mainWindow.loadURL(path.normalize('file://' + __dirname + '/app/index.html'));
+		var extraParams = process.argv.length > 1 ? process.argv[1] : "";
+		mainWindow.loadURL(path.normalize('file://' + __dirname + '/app/index.html?' + extraParams));
 
 		mainWindow.on('closed', function ()
 		{


### PR DESCRIPTION
Adding command line options and enable to pass a path for a configuration.

Start with params on Mac OS:
`open -a /Applications/PiBakery.app --args importRecipe=/path/to/recipe.xml`

Not tested on Windows or Linux. Should be
`PiBakery --importRecipe=/path/to/recipe.xml`