### PR TITLE
Additional blocks for SSH configuration

### DIFF
--- a/pibakery-blocks/sshenable/sshenable.json
+++ b/pibakery-blocks/sshenable/sshenable.json
@@ -1,0 +1,21 @@
+{
+	"name": "sshenable",
+	"text": "%1 secure shell (SSH) server",
+	"script": "sshenable.sh",
+	"args": [
+		{
+			"type": "menu",
+			"options": ["Enable", "Disable"]
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "software",
+	"category":"software",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Enable or disable the SSH server.",
+	"longDescription":"By default, the built in secure shell (SSH) server does not run on startup. Using this block you can enable it, or disable it if you have already enabled it."
+}

--- a/pibakery-blocks/sshenable/sshenable.sh
+++ b/pibakery-blocks/sshenable/sshenable.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$1" == "Enable" ]
+then
+  systemctl enable ssh
+  systemctl start ssh
+else
+  systemctl disable ssh
+  systemctl stop ssh
+fi

--- a/pibakery-blocks/sshpasswordauth/sshpasswordauth.json
+++ b/pibakery-blocks/sshpasswordauth/sshpasswordauth.json
@@ -1,0 +1,21 @@
+{
+	"name": "sshpasswordauth",
+	"text": "%1 SSH password authentication",
+	"script": "sshpasswordauth.sh",
+	"args": [
+		{
+			"type": "menu",
+			"options": ["Enable", "Disable"]
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "setting",
+	"category":"setting",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Enable or disable password authentication for the SSH server.",
+	"longDescription":"The secure shell (SSH) service supports password authentication by default. Use this setting to disable it, and allow SSH access only via public key authentication. Make sure you have authorized a public key first!"
+}

--- a/pibakery-blocks/sshpasswordauth/sshpasswordauth.sh
+++ b/pibakery-blocks/sshpasswordauth/sshpasswordauth.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$1" == "Enable" ]
+then
+	sed -re 's/^(\#?)(PasswordAuthentication)([[:space:]]+)(no|yes)[[:space:]]*$/\2\3yes/' -i /etc/ssh/sshd_config
+else
+	sed -re 's/^(\#?)(PasswordAuthentication)([[:space:]]+)(no|yes)[[:space:]]*$/\2\3no/' -i /etc/ssh/sshd_config
+fi
+systemctl reload sshd


### PR DESCRIPTION
Two blocks for enabling/disabling the SSH server, and the PasswordAuthentication configuration option.
So you can, for example, enable the SSH service and disallow password logins.