### PR TITLE
make wmic call pull path

### DIFF
--- a/app/pibakery.js
+++ b/app/pibakery.js
@@ -1792,7 +1792,7 @@ function getDriveListWin (callback) {
     }else {
       var length = disks.length
 
-      var drives = shellParser(execSync('wmic logicaldisk get caption,volumename,drivetype', {stdio: [null, null, null]}).toString())
+      var drives = shellParser(execSync('C:\Windows\System32\wbem\wmic logicaldisk get caption,volumename,drivetype', {stdio: [null, null, null]}).toString())
 
       for ( var x = 0; x < disks.length; x++) {
         for ( var y = 0; y < drives.length; y++) {


### PR DESCRIPTION
fixes bug where windows PATH not set properly causes wmic command to fail
wmic now calls full path rather than the shortcut which works on all Windows installations