### PR TITLE
Update wifiConnect.py, setting -i wlan0 to wpa_cli

### DIFF
--- a/pibakery-blocks/wifisetup/wifiConnect.py
+++ b/pibakery-blocks/wifisetup/wifiConnect.py
@@ -47,7 +47,7 @@ os.system('raspi-config nonint do_wifi_country "' + countryCode + '"')
 with open("/etc/wpa_supplicant/wpa_supplicant.conf", "a") as wifiFile:
 	wifiFile.write(wifiText)
 
-os.system("wpa_cli reconfigure")
+os.system("wpa_cli -i wlan0 reconfigure")
 time.sleep(5)
 #os.system("systemctl daemon-reload")
 #time.sleep(5)


### PR DESCRIPTION
Added the parameter "-i wlan0" in the command "wpa_cli reconfigure". When this block is being used in the first boot, the command "wpa_cli reconfigure" is selecting the interface "p2p-dev-wlan0" and the Raspberry doesn't connect in the WiFi. Using -i wlan0 to force it to use the default interface.